### PR TITLE
feat: Implement core ActivityPub types and placeholders

### DIFF
--- a/src/activitypub/inbox.ts
+++ b/src/activitypub/inbox.ts
@@ -1,0 +1,25 @@
+import { APObject, ActivitySchema } from './types';
+import { parse, ValiError } from 'valibot';
+
+/**
+ * Processes an incoming ActivityPub activity from the inbox.
+ *
+ * @param activity The potential activity object.
+ * @returns True if the activity is valid and processed, false otherwise.
+ */
+export function processInboxActivity(activity: APObject): boolean {
+  try {
+    const parsedActivity = parse(ActivitySchema, activity);
+    // TODO: Differentiate activity types (Create, Follow, Like, Announce)
+    // TODO: Based on type, perform specific actions (e.g., store data, send notifications)
+    console.log("Processing activity:", parsedActivity);
+    return true;
+  } catch (error) {
+    if (error instanceof ValiError) {
+      console.error("Invalid activity:", error.issues);
+    } else {
+      console.error("An unexpected error occurred during activity processing:", error);
+    }
+    return false;
+  }
+}

--- a/src/activitypub/outbox.ts
+++ b/src/activitypub/outbox.ts
@@ -1,0 +1,29 @@
+import { APObject, ActivitySchema } from './types';
+import { parse, ValiError } from 'valibot';
+
+/**
+ * Parses and "sends" an ActivityPub activity to a target URL.
+ * Currently, it only simulates sending by logging to the console.
+ *
+ * @param activity The activity object to send.
+ * @param targetUrl The URL of the target inbox.
+ * @returns A promise that resolves to true if the activity is valid and "sent" (simulated),
+ *          and false if the activity is invalid or an error occurs.
+ */
+export async function sendActivity(activity: APObject, targetUrl: string): Promise<boolean> {
+  try {
+    const parsedActivity = parse(ActivitySchema, activity);
+    console.log(`Simulating sending activity: ${parsedActivity.id} to ${targetUrl}`);
+    // TODO: Implement actual HTTP POST request logic here.
+    // This will involve using a fetch-like library to send `parsedActivity`
+    // as JSON to the `targetUrl` with appropriate headers (e.g., Content-Type: application/activity+json).
+    return true;
+  } catch (error) {
+    if (error instanceof ValiError) {
+      console.error("Invalid activity for outbox:", error.issues);
+    } else {
+      console.error("An unexpected error occurred while preparing to send activity:", error);
+    }
+    return false;
+  }
+}

--- a/src/activitypub/types.ts
+++ b/src/activitypub/types.ts
@@ -22,3 +22,61 @@ export const APActorSchema = v.intersect([
   }),
 ]);
 export type APActor = v.Input<typeof APActorSchema>;
+
+// Activity Schemas
+export const ActivitySchema = v.intersect([
+  APObjectSchema,
+  v.object({
+    actor: v.union([APActorSchema, v.string([v.url()])]),
+    object: v.union([APObjectSchema, v.string([v.url()])]),
+  }),
+]);
+export type Activity = v.Input<typeof ActivitySchema>;
+
+export const CreateActivitySchema = v.intersect([
+  ActivitySchema,
+  v.object({
+    type: v.literal('Create'),
+  }),
+]);
+export type CreateActivity = v.Input<typeof CreateActivitySchema>;
+
+export const FollowActivitySchema = v.intersect([
+  ActivitySchema,
+  v.object({
+    type: v.literal('Follow'),
+    object: v.union([APActorSchema, v.string([v.url()])]), // Override object type
+  }),
+]);
+export type FollowActivity = v.Input<typeof FollowActivitySchema>;
+
+export const LikeActivitySchema = v.intersect([
+  ActivitySchema,
+  v.object({
+    type: v.literal('Like'),
+  }),
+]);
+export type LikeActivity = v.Input<typeof LikeActivitySchema>;
+
+export const AnnounceActivitySchema = v.intersect([
+  ActivitySchema,
+  v.object({
+    type: v.literal('Announce'),
+  }),
+]);
+export type AnnounceActivity = v.Input<typeof AnnounceActivitySchema>;
+
+// WebFinger Schemas
+export const WebFingerLinkSchema = v.object({
+  rel: v.string(),
+  type: v.optional(v.string()),
+  href: v.optional(v.string([v.url()])),
+});
+export type WebFingerLink = v.Input<typeof WebFingerLinkSchema>;
+
+export const WebFingerSchema = v.object({
+  subject: v.string(),
+  aliases: v.optional(v.array(v.string([v.url()]))),
+  links: v.optional(v.array(WebFingerLinkSchema)),
+});
+export type WebFinger = v.Input<typeof WebFingerSchema>;

--- a/tests/activitypub/inbox.test.ts
+++ b/tests/activitypub/inbox.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { processInboxActivity } from '../../src/activitypub/inbox';
+import { APActor, APObject } from '../../src/activitypub/types'; // Included as requested
+
+describe('processInboxActivity', () => {
+  const mockActor: APActor = {
+    id: 'https://example.com/users/testuser',
+    type: 'Person',
+    inbox: 'https://example.com/users/testuser/inbox',
+    outbox: 'https://example.com/users/testuser/outbox',
+    name: 'Test User',
+  };
+
+  const mockObject: APObject = {
+    id: 'https://example.com/objects/note1',
+    type: 'Note',
+    content: 'This is a test note.',
+  };
+
+  // Test Case 1: Valid Activity
+  it('should return true and log the activity for a valid activity', () => {
+    const validActivity = {
+      id: 'https://example.com/activities/create1',
+      type: 'Create',
+      actor: mockActor,
+      object: mockObject,
+      published: new Date().toISOString(),
+    };
+
+    const consoleLogSpy = vi.spyOn(console, 'log');
+    const result = processInboxActivity(validActivity as APObject); // Cast as APObject for input
+
+    expect(result).toBe(true);
+    expect(consoleLogSpy).toHaveBeenCalled();
+    // Check if the logged message contains the activity's ID (or a more specific check if needed)
+    expect(consoleLogSpy).toHaveBeenCalledWith("Processing activity:", expect.objectContaining({ id: validActivity.id }));
+
+    consoleLogSpy.mockRestore();
+  });
+
+  // Test Case 2: Invalid Activity (Missing Actor)
+  it('should return false and log an error for an activity missing the actor field', () => {
+    const invalidActivityMissingActor = {
+      id: 'https://example.com/activities/invalid2',
+      type: 'Create',
+      // actor: mockActor, // Actor is missing
+      object: mockObject,
+      published: new Date().toISOString(),
+    };
+
+    const consoleErrorSpy = vi.spyOn(console, 'error');
+    const result = processInboxActivity(invalidActivityMissingActor as APObject);
+
+    expect(result).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    // Check if the error message indicates issues (Valibot's specific error structure)
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Invalid activity:", expect.any(Array));
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  // Test Case 3: Invalid Activity (Wrong Type for a field)
+  it('should return false and log an error for an activity with a field of an incorrect type', () => {
+    const invalidActivityWrongFieldType = {
+      id: 'https://example.com/activities/invalid3',
+      type: 'Like',
+      actor: mockActor,
+      object: 12345, // Object should be an APObject or a URL string, not a number
+      published: new Date().toISOString(),
+    };
+
+    const consoleErrorSpy = vi.spyOn(console, 'error');
+    const result = processInboxActivity(invalidActivityWrongFieldType as APObject);
+
+    expect(result).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Invalid activity:", expect.any(Array));
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/tests/activitypub/outbox.test.ts
+++ b/tests/activitypub/outbox.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { sendActivity } from '../../src/activitypub/outbox';
+import { APActor, APObject } from '../../src/activitypub/types'; // Included as requested
+
+describe('sendActivity', () => {
+  const mockActor: APActor = {
+    id: 'https://example.com/users/sender',
+    type: 'Person',
+    inbox: 'https://example.com/users/sender/inbox',
+    outbox: 'https://example.com/users/sender/outbox',
+    name: 'Sender User',
+  };
+
+  const mockObject: APObject = {
+    id: 'https://example.com/objects/message1',
+    type: 'Note',
+    content: 'Hello world!',
+  };
+
+  const targetUrl = 'https://target.example.com/inbox';
+
+  // Test Case 1: Valid Activity
+  it('should return true and log simulation message for a valid activity', async () => {
+    const validActivity = {
+      id: 'https://example.com/activities/post1',
+      type: 'Create',
+      actor: mockActor,
+      object: mockObject,
+      published: new Date().toISOString(),
+    };
+
+    const consoleLogSpy = vi.spyOn(console, 'log');
+    const result = await sendActivity(validActivity as APObject, targetUrl);
+
+    expect(result).toBe(true);
+    expect(consoleLogSpy).toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith(`Simulating sending activity: ${validActivity.id} to ${targetUrl}`);
+
+    consoleLogSpy.mockRestore();
+  });
+
+  // Test Case 2: Invalid Activity (Missing Object)
+  it('should return false and log error for an invalid activity (missing object)', async () => {
+    const invalidActivityMissingObject = {
+      id: 'https://example.com/activities/invalid1',
+      type: 'Create',
+      actor: mockActor,
+      // object: mockObject, // Object is missing
+      published: new Date().toISOString(),
+    };
+
+    const consoleErrorSpy = vi.spyOn(console, 'error');
+    const result = await sendActivity(invalidActivityMissingObject as APObject, targetUrl);
+
+    expect(result).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    // Check if the error message indicates issues related to 'object' field
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Invalid activity for outbox:", expect.arrayContaining([
+      expect.objectContaining({
+        path: expect.arrayContaining([expect.objectContaining({ key: 'object' })]),
+      }),
+    ]));
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  // Test Case 3: Invalid Activity (Actor is not a valid AP Actor or URL string)
+  it('should return false and log error for an invalid activity (invalid actor type)', async () => {
+    const invalidActivityInvalidActor = {
+      id: 'https://example.com/activities/invalid2',
+      type: 'Create',
+      actor: { name: "Just a name", type: "Invalid" }, // Not a valid APActor or URL
+      object: mockObject,
+      published: new Date().toISOString(),
+    };
+    
+    const consoleErrorSpy = vi.spyOn(console, 'error');
+    const result = await sendActivity(invalidActivityInvalidActor as APObject, targetUrl);
+
+    expect(result).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Invalid activity for outbox:", expect.arrayContaining([
+      expect.objectContaining({
+        path: expect.arrayContaining([expect.objectContaining({ key: 'actor' })]),
+      }),
+    ]));
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/tests/activitypub/types.test.ts
+++ b/tests/activitypub/types.test.ts
@@ -1,6 +1,41 @@
 import { describe, it, expect } from 'vitest';
 import * as v from 'valibot';
-import { APObjectSchema, APActorSchema } from '../../src/activitypub/types';
+import {
+  APObjectSchema,
+  APActorSchema,
+  ActivitySchema,
+  CreateActivitySchema,
+  FollowActivitySchema,
+  LikeActivitySchema,
+  AnnounceActivitySchema,
+  WebFingerLinkSchema,
+  WebFingerSchema,
+} from '../../src/activitypub/types';
+
+// Base objects for reusability
+const baseObject: v.Input<typeof APObjectSchema> = {
+  id: 'https://example.com/object/1',
+  type: 'Note',
+  content: 'This is a test note.',
+  published: new Date().toISOString(),
+};
+
+const baseActor: v.Input<typeof APActorSchema> = {
+  id: 'https://example.com/users/testactor',
+  type: 'Person',
+  name: 'Test Actor',
+  inbox: 'https://example.com/users/testactor/inbox',
+  outbox: 'https://example.com/users/testactor/outbox',
+  preferredUsername: 'testactor',
+};
+
+const baseActivity = {
+  id: 'https://example.com/activity/1',
+  type: 'Activity', // Generic type for base, will be overridden
+  actor: baseActor,
+  object: baseObject,
+  published: new Date().toISOString(),
+};
 
 describe('ActivityPub Valibot Schemas', () => {
   describe('APObjectSchema', () => {
@@ -58,6 +93,309 @@ describe('ActivityPub Valibot Schemas', () => {
         outbox: 'https://example.com/users/actor/outbox',
       };
       expect(() => v.parse(APActorSchema, invalidActor)).toThrow();
+    });
+  });
+
+  describe('ActivitySchema', () => {
+    it('should validate a correct Activity with actor and object as full objects', () => {
+      const validActivity = { ...baseActivity, type: 'Activity' };
+      const result = v.safeParse(ActivitySchema, validActivity);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate a correct Activity with actor and object as URLs', () => {
+      const validActivity = {
+        ...baseActivity,
+        type: 'Activity',
+        actor: 'https://example.com/users/actor-url',
+        object: 'https://example.com/objects/object-url',
+      };
+      const result = v.safeParse(ActivitySchema, validActivity);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate a correct Activity with actor as object and object as URL', () => {
+      const validActivity = {
+        ...baseActivity,
+        type: 'Activity',
+        actor: baseActor,
+        object: 'https://example.com/objects/object-url',
+      };
+      const result = v.safeParse(ActivitySchema, validActivity);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate a correct Activity with actor as URL and object as object', () => {
+      const validActivity = {
+        ...baseActivity,
+        type: 'Activity',
+        actor: 'https://example.com/users/actor-url',
+        object: baseObject,
+      };
+      const result = v.safeParse(ActivitySchema, validActivity);
+      expect(result.success).toBe(true);
+    });
+
+    it('should invalidate an Activity missing actor', () => {
+      const invalidActivity = { ...baseActivity, actor: undefined, type: 'Activity' };
+      const result = v.safeParse(ActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('actor');
+    });
+
+    it('should invalidate an Activity missing object', () => {
+      const invalidActivity = { ...baseActivity, object: undefined, type: 'Activity' };
+      const result = v.safeParse(ActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('object');
+    });
+
+    it('should invalidate an Activity with actor as invalid type (not Actor or URL)', () => {
+      const invalidActivity = { ...baseActivity, actor: { id: 'foo' }, type: 'Activity' }; // missing actor fields
+      const result = v.safeParse(ActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('actor');
+    });
+
+    it('should invalidate an Activity with object as invalid type (not APObject or URL)', () => {
+      const invalidActivity = { ...baseActivity, object: { name: 'only name' }, type: 'Activity' }; // missing object id/type
+      const result = v.safeParse(ActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('object');
+    });
+  });
+
+  describe('CreateActivitySchema', () => {
+    const validCreateActivity = {
+      ...baseActivity,
+      type: 'Create' as const, // Ensure literal type
+    };
+
+    it('should validate a correct CreateActivity', () => {
+      const result = v.safeParse(CreateActivitySchema, validCreateActivity);
+      expect(result.success).toBe(true);
+    });
+
+    it('should invalidate a CreateActivity with incorrect type', () => {
+      const invalidActivity = { ...validCreateActivity, type: 'Like' as const };
+      const result = v.safeParse(CreateActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('type');
+    });
+
+    it('should invalidate a CreateActivity missing type', () => {
+      const { type, ...rest } = validCreateActivity; // remove type
+      const invalidActivity = rest;
+      const result = v.safeParse(CreateActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('type');
+    });
+
+
+    it('should invalidate a CreateActivity missing actor', () => {
+      const invalidActivity = { ...validCreateActivity, actor: undefined };
+      const result = v.safeParse(CreateActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('actor');
+    });
+
+    it('should invalidate a CreateActivity missing object', () => {
+      const invalidActivity = { ...validCreateActivity, object: undefined };
+      const result = v.safeParse(CreateActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('object');
+    });
+  });
+
+  describe('FollowActivitySchema', () => {
+    const validFollowActivityBase = {
+      ...baseActivity,
+      actor: baseActor, // follower
+      type: 'Follow' as const,
+    };
+
+    it('should validate a correct FollowActivity with object as APActorSchema', () => {
+      const validActivity = { ...validFollowActivityBase, object: baseActor }; // following baseActor
+      const result = v.safeParse(FollowActivitySchema, validActivity);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate a correct FollowActivity with object as URL string', () => {
+      const validActivity = { ...validFollowActivityBase, object: 'https://example.com/users/tobefollowed' };
+      const result = v.safeParse(FollowActivitySchema, validActivity);
+      expect(result.success).toBe(true);
+    });
+
+    it('should invalidate a FollowActivity with incorrect type', () => {
+      const invalidActivity = { ...validFollowActivityBase, object: baseActor, type: 'Like' as const };
+      const result = v.safeParse(FollowActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('type');
+    });
+
+    it('should invalidate a FollowActivity with object as APObject (not Actor or URL)', () => {
+      const invalidActivity = { ...validFollowActivityBase, object: baseObject }; // Trying to follow a Note
+      const result = v.safeParse(FollowActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('object');
+    });
+
+    it('should invalidate a FollowActivity with object as invalid type', () => {
+      const invalidActivity = { ...validFollowActivityBase, object: { id: 'foo' } }; // Not a valid Actor or URL
+      const result = v.safeParse(FollowActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('object');
+    });
+
+    it('should invalidate a FollowActivity missing object', () => {
+        const invalidActivity = { ...validFollowActivityBase, object: undefined };
+        const result = v.safeParse(FollowActivitySchema, invalidActivity);
+        expect(result.success).toBe(false);
+        expect(result.issues?.[0].path?.[0].key).toBe('object');
+    });
+  });
+
+  describe('LikeActivitySchema', () => {
+    const validLikeActivity = {
+      ...baseActivity,
+      type: 'Like' as const,
+      object: baseObject, // Liking a Note
+    };
+
+    it('should validate a correct LikeActivity', () => {
+      const result = v.safeParse(LikeActivitySchema, validLikeActivity);
+      expect(result.success).toBe(true);
+    });
+
+    it('should invalidate a LikeActivity with incorrect type', () => {
+      const invalidActivity = { ...validLikeActivity, type: 'Create' as const };
+      const result = v.safeParse(LikeActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('type');
+    });
+
+    it('should invalidate a LikeActivity missing object', () => {
+      const invalidActivity = { ...validLikeActivity, object: undefined };
+      const result = v.safeParse(LikeActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('object');
+    });
+  });
+
+  describe('AnnounceActivitySchema', () => {
+    const validAnnounceActivity = {
+      ...baseActivity,
+      type: 'Announce' as const,
+      object: baseObject, // Announcing a Note
+    };
+
+    it('should validate a correct AnnounceActivity', () => {
+      const result = v.safeParse(AnnounceActivitySchema, validAnnounceActivity);
+      expect(result.success).toBe(true);
+    });
+
+    it('should invalidate an AnnounceActivity with incorrect type', () => {
+      const invalidActivity = { ...validAnnounceActivity, type: 'Like' as const };
+      const result = v.safeParse(AnnounceActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('type');
+    });
+
+    it('should invalidate an AnnounceActivity missing object', () => {
+      const invalidActivity = { ...validAnnounceActivity, object: undefined };
+      const result = v.safeParse(AnnounceActivitySchema, invalidActivity);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('object');
+    });
+  });
+});
+
+describe('WebFinger Schemas', () => {
+  describe('WebFingerLinkSchema', () => {
+    it('should validate a correct WebFingerLink with all fields', () => {
+      const validLink = {
+        rel: 'profile',
+        type: 'application/activity+json',
+        href: 'https://example.com/users/profile',
+      };
+      const result = v.safeParse(WebFingerLinkSchema, validLink);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate a correct WebFingerLink with only rel (minimal)', () => {
+      const validLink = { rel: 'self' };
+      const result = v.safeParse(WebFingerLinkSchema, validLink);
+      expect(result.success).toBe(true);
+    });
+
+    it('should invalidate a WebFingerLink missing rel', () => {
+      const invalidLink = { type: 'application/activity+json', href: 'https://example.com/users/profile' };
+      const result = v.safeParse(WebFingerLinkSchema, invalidLink);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('rel');
+    });
+
+    it('should invalidate a WebFingerLink with href not being a URL', () => {
+      const invalidLink = { rel: 'profile', href: 'not-a-url' };
+      const result = v.safeParse(WebFingerLinkSchema, invalidLink);
+      expect(result.success).toBe(false);
+      // Valibot's URL validation is nested, so we check for the 'href' key in the path
+      expect(result.issues?.[0].path?.some(p => p.key === 'href')).toBe(true);
+    });
+  });
+
+  describe('WebFingerSchema (JRD)', () => {
+    const validLink1 = { rel: 'self', type: 'application/activity+json', href: 'https://example.com/actor' };
+    const validLink2 = { rel: 'profile', type: 'text/html', href: 'https://example.com/profile/actor' };
+
+    it('should validate a correct WebFinger JRD with subject, aliases, and links', () => {
+      const validJRD = {
+        subject: 'acct:user@example.com',
+        aliases: ['https://example.com/users/user', 'https://another.example/user'],
+        links: [validLink1, validLink2],
+      };
+      const result = v.safeParse(WebFingerSchema, validJRD);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate a correct WebFinger JRD with only subject (minimal)', () => {
+      const validJRD = { subject: 'acct:user@example.com' };
+      const result = v.safeParse(WebFingerSchema, validJRD);
+      expect(result.success).toBe(true);
+    });
+
+    it('should invalidate a WebFinger JRD missing subject', () => {
+      const invalidJRD = {
+        aliases: ['https://example.com/users/user'],
+        links: [validLink1],
+      };
+      const result = v.safeParse(WebFingerSchema, invalidJRD);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('subject');
+    });
+
+    it('should invalidate a WebFinger JRD with links containing invalid link objects', () => {
+      const invalidLink = { type: 'application/json' }; // Missing 'rel'
+      const invalidJRD = {
+        subject: 'acct:user@example.com',
+        links: [validLink1, invalidLink],
+      };
+      const result = v.safeParse(WebFingerSchema, invalidJRD);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('links');
+      expect(result.issues?.[0].path?.[2].key).toBe('rel'); // Path to the 'rel' inside the second link
+    });
+
+    it('should invalidate a WebFinger JRD with aliases containing non-URL strings', () => {
+      const invalidJRD = {
+        subject: 'acct:user@example.com',
+        aliases: ['https://example.com/users/user', 'not-a-url'],
+      };
+      const result = v.safeParse(WebFingerSchema, invalidJRD);
+      expect(result.success).toBe(false);
+      expect(result.issues?.[0].path?.[0].key).toBe('aliases');
+       // Check that the issue is related to the URL validation within the array
+      expect(result.issues?.[0].validation).toBe('url');
     });
   });
 });


### PR DESCRIPTION
I've implemented initial schemas and types for ActivityPub core entities:
- APObjectSchema: Base object schema.
- APActorSchema: Schema for actors (e.g., Person, Service).
- ActivitySchema: Base schema for activities, extending APObject.
- Specific Activity Schemas: Create, Follow, Like, Announce.
- WebFingerSchema: For JRD responses, including WebFingerLinkSchema.

I've also added placeholder functions for future development:
- `processInboxActivity(activity)` in `src/activitypub/inbox.ts`: Validates and logs incoming activities.
- `sendActivity(activity, targetUrl)` in `src/activitypub/outbox.ts`: Validates and logs activities for sending.

Comprehensive unit tests using vitest and valibot have been added for all new schemas and placeholder functions to ensure correctness and provide a solid foundation for further ActivityPub implementation.